### PR TITLE
Version up to v0.2.0

### DIFF
--- a/camorph/ext/MPEG_OMAF/MPEG_OMAF.py
+++ b/camorph/ext/MPEG_OMAF/MPEG_OMAF.py
@@ -43,6 +43,13 @@ class MPEG_OMAF(FileHandler):
                 else:
                     cam.focal_length_px = [cam.resolution[0] / 2,cam.resolution[0] / 2]
                     cam.principal_point = [x / 2 for x in cam.resolution]
+
+                if cam.resolution is not None:
+                    if cam.resolution[0] > cam.resolution[1]:
+                        cam.sensor_size = (36, (36 / cam.resolution[0]) * cam.resolution[1])
+                    else:
+                        cam.sensor_size = ((36 / cam.resolution[1]) * cam.resolution[0], 36)
+                
                 cam_arr.append(cam)
             if len(args) == 1 and type(args[0]) == str and args[0].split('.')[-1] == 'csv':
                 basecam = next((c for c in cam_arr if c.name == 'viewport'), None)
@@ -91,7 +98,7 @@ class MPEG_OMAF(FileHandler):
             json_cam = {
                 'Name': cam.name,
                 'Position': [float(x) for x in cam.t],
-                'Rotation': [float(x) for x in math_utils.quaternion_to_euler(cam.r)],
+                'Rotation': [float(x) for x in math_utils.quaternion_to_euler(cam.r)[::-1]],
                 'Depthmap': 1,
                 'Background': 0,
                 'Depth_range': [40.0,70.0],

--- a/camorph/ext/NeRF/NeRF.py
+++ b/camorph/ext/NeRF/NeRF.py
@@ -195,7 +195,11 @@ class NeRF(FileHandler):
 
             if os.path.isabs(cam.source_image):
                 warnings.warn("Camorph needs absolute image Paths. Relative paths are automatically calculated when saving to NeRF")
-                source_image = os.path.relpath(source_image,output_path)
+                tmp_output_path = output_path
+                if not os.path.isdir(tmp_output_path):
+                    tmp_output_path = os.path.split(output_path)[0]
+
+                source_image = os.path.relpath(source_image,tmp_output_path)
 
             json_cam = {
                 'intrinsics': {},

--- a/camorph/lib/utils/math_utils.py
+++ b/camorph/lib/utils/math_utils.py
@@ -14,7 +14,7 @@ from pyquaternion import Quaternion
 
 
 def euler_to_quaternion(vec, rot_order='xyz'):
-    """This function converts a set of euler angles to a quaternion.
+    """This function converts a set of Euler angles to a quaternion.
 
 
         :param vec: Vector as xyz
@@ -32,7 +32,7 @@ def euler_to_quaternion(vec, rot_order='xyz'):
 
 
 def quaternion_to_euler(q, rot_order='xyz'):
-    """This function converts a quaternion of euler angles to a quaternion.
+    """This function converts a quaternion to a set of Euler angles.
 
 
         :param q: Quaternion

--- a/camorph/lib/visualizer.py
+++ b/camorph/lib/visualizer.py
@@ -23,8 +23,8 @@ def visualize(cams: list[Camera]):
     upx, upy, upz = zip(*[x.r.rotate(up) for x in cams])
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
-    ax.quiver(x, y, z, dirx, diry, dirz, color='r')
-    ax.quiver(x, y, z, upx, upy, upz, color='g')
+    ax.quiver(x, y, z, dirx, diry, dirz, color='r', label='Camera Front')
+    ax.quiver(x, y, z, upx, upy, upz, color='g', label='Camera Up')
 
     ax.set_xlim([-maxdist, maxdist])
     ax.set_ylim([-maxdist, maxdist])
@@ -34,5 +34,7 @@ def visualize(cams: list[Camera]):
     ax.set_xlabel('X')
     ax.set_ylabel('Y')
     ax.set_zlabel('Z')
+
+    ax.legend()
 
     plt.show()

--- a/camorph_cli.bat
+++ b/camorph_cli.bat
@@ -1,21 +1,17 @@
 @echo off
 
 :: Modify Camorph parameters here
-SET inputType=fbx
-SET inputFolder=YourInputFolder
-SET input=YourInputFile.extension
+:: Possible format types: fbx, colmap, unity, nerf, reality_capture, mpeg_omaf
+SET inputType=colmap
+SET inputFolder=\\path\to\your\input
+SET input=%inputFolder%
 
-SET outputType1=reality_capture
-::SET outputType2=colmap
+SET outputType=nerf
 SET outputFolder=%inputFolder%
-SET output1=%outputFolder%\YourOutputFolder
-::SET output2=%outputFolder%\CamorphCOLMAP
+SET output=%outputFolder%\CamorphJSON\transforms.json
 
  
-:: First Camorph output
-python -m camorph -if %inputType% -i "%input%" -of %outputType1% -o "%output1%"
-
-
-:: Second Camorph output
-::python -m camorph -if %inputType% -i "%input%" -of %outputType2% -o "%output2%"
+:: Camorph output
+:: Additional arguments: -ft (for colmap to switch between txt and bin), -pt (for pose traces)
+python -m camorph -if %inputType% -i "%input%" -of %outputType% -o "%output%"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 exclude=["thirdPartyLegalNotices"]
 [project]
 name = "camorph"
-version = "0.1.3"
+version = "0.2.0"
 description = "Camorph is a python library for converting different camera parameter representations into each other"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
- Cleaned up camorph_cli.bat
- Added legend for visualizer (front, up vectors)
- Fixed an issue with relative paths if output path contains the filename
- Fixed a bug when writing MPEG OMAF format (Euler angle order)
- Fixed an issue when reading MPEG OMAF format (automatic focal_length conversion from px to mm was not triggered)