### PR TITLE
Fix image detection for COLMAP

### DIFF
--- a/camorph/ext/COLMAP/COLMAP.py
+++ b/camorph/ext/COLMAP/COLMAP.py
@@ -124,6 +124,8 @@ class COLMAP(FileHandler):
             else:
                 images_dir = os.path.join(os.path.dirname(os.path.dirname(input_path_images)), 'images')
                 if not os.path.isdir(images_dir):
+                    images_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(input_path_images))), 'images')
+                if not os.path.isdir(images_dir):
                     warnings.warn(
                         'Camorph could not locate the COLMAP images folder. When writing, make sure to supply a config.json')
                 else:


### PR DESCRIPTION
The COLMAP binaries are not always in the directory sparse, but in sparse/0. This is the case for some popular datasets used for NeRFs such as the MipNeRF360 dataset.

If this is the case the cameras do not contain the source images. To fix this I've added a check for the different directory.