### PR TITLE
Correctly set principal point if it is not specified

### DIFF
--- a/camorph/ext/NeRF/NeRF.py
+++ b/camorph/ext/NeRF/NeRF.py
@@ -101,10 +101,6 @@ class NeRF(FileHandler):
             if len(cam.radial_distortion) > 0 or len(cam.tangential_distortion) > 0:
                 cam.model='brown'
 
-            if None not in principal_point:
-                cam.principal_point = [float(x) for x in principal_point]
-            set_local(local_principal_point, "principal_point", cam)
-
             bname = os.path.basename(c['file_path'])
             if 'posetrace' in kwargs and kwargs['posetrace'] is True:
                 img = bname
@@ -127,6 +123,14 @@ class NeRF(FileHandler):
                     cam.resolution = i.size
 
             set_local(local_resolution, "resolution", cam, int)
+
+            if None not in principal_point:
+                cam.principal_point = [float(x) for x in principal_point]
+            if None not in local_principal_point:
+                set_local(local_principal_point, "principal_point", cam)
+            if cam.principal_point is None:
+                principal_point_from_resolution = [side_length / 2 for side_length in cam.resolution]
+                set_local(principal_point_from_resolution, "principal_point", cam)
 
             if fl_x is not None:
                 if fl_y is not None:


### PR DESCRIPTION
Loading NeRF data which does not specify the principal point causes a problem with the autocomputation of the other attributes:

```
File "/home/branschke/3dgs/ffsplat/src/camorph/ext/NeRF/NeRF.py", line 127, in read_file
    cam.resolution = i.size
    ^^^^^^^^^^^^^^
  File "/home/branschke/3dgs/ffsplat/src/camorph/lib/model/Camera.py", line 214, in __setattr__
    self.lens_shift = self._lens_shift()
                      ^^^^^^^^^^^^^^^^^^
  File "/home/branschke/3dgs/ffsplat/src/camorph/lib/model/Camera.py", line 188, in _lens_shift
    return self.principal_point[0] / self.resolution[0] - 0.5, self.principal_point[1] / self.resolution[1] - 0.5
           ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```

If there is no principal point specified it is set to `[None, None]`. `_has_or_none()` returns `True` for this value. Instead the principal point should be set to the middle of the image, as in `write_file()`
